### PR TITLE
Fixing chromedriver download helper

### DIFF
--- a/helper/driver.py
+++ b/helper/driver.py
@@ -2,7 +2,6 @@ import os
 import zipfile
 import requests
 import env
-import shutil
 
 def update_driver():
     os.remove("drivers/chromedriver.exe")
@@ -20,20 +19,35 @@ def download_driver(driver_path, system):
     response = requests.get(url, stream=True)
     zip_file_path = os.path.join(os.path.dirname(
         driver_path), os.path.basename(url))
+    # save response into zipfile
     with open(zip_file_path, "wb") as handle:
         for chunk in response.iter_content(chunk_size=512):
             if chunk:  # filter out keep alive chunks
                 handle.write(chunk)
+    
     extracted_dir = os.path.splitext(zip_file_path)[0]
+    # extract zipfile
     with zipfile.ZipFile(zip_file_path, "r") as zip_file:
         zip_file.extractall(extracted_dir)
+    # remove zip
     os.remove(zip_file_path)
 
-    driver = os.listdir(extracted_dir)[0]
-    os.rename(os.path.join(extracted_dir, driver), driver_path)
-    shutil.rmtree(extracted_dir)
+    # get driver from extracted files
+    driver = None
+    for filename in os.listdir(extracted_dir):
+        if filename.lower().startswith("chromedriver"):
+            driver = filename
 
-    os.chmod(driver_path, 0o755)
-    # way to note which chromedriver version is installed
-    open(os.path.join(os.path.dirname(driver_path),
-                      "{}.txt".format(latest_version)), "w").close()
+    if driver:
+        # move driver to driver_path (parent folder)
+        os.rename(os.path.join(extracted_dir, driver), driver_path)
+        os.rmdir(extracted_dir)
+        # add execution permissions
+        os.chmod(driver_path, 0o755)
+        # way to note which chromedriver version is installed
+        open(os.path.join(os.path.dirname(driver_path),
+                        "{}.txt".format(latest_version)), "w").close()
+    else:
+        raise Exception("Error finding driver from downloaded file")
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-selenium==4.0.0b4
+selenium==4.1.1
 requests==2.27.1
 pyotp==2.6.0
 python-telegram-bot==13.7


### PR DESCRIPTION
## Context
There's a bug in the code when downloading and extracting the `chromedriver` (used by selenium), the file used as the driver is sometimes the wrong one. This happens since there are two files contained in the zip file, the actual driver and the license. Once the zip file is extracted, the first file is used: `os.listdir(extracted_dir)[0]`. But it turns out that `os.listdir` [doesn't guarantee an order](https://docs.python.org/3/library/os.html#os.listdir), thus in some occasions the license is used as a driver instead.

## Changes
- [x] Looking up for the driver using the file name instead of the first one from the directory.
- [x] Updating selenium driver since `pip` was having issues solving the set version in `requirements.txt`.

# Further improvement
- Use a better solution to download the driver and is platform agnostic as [chromedriver-autoinstaller](https://pypi.org/project/chromedriver-autoinstaller).